### PR TITLE
Use String array offsets instead of BRL.Retro.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@
 /sct.debug
 /sct.exe
 /sct.debug.exe
-
+*.bak
 

--- a/app.testmanager.bmx
+++ b/app.testmanager.bmx
@@ -1,4 +1,4 @@
-REM
+Rem
 	===========================================================
 	APP SPECIFIC COMPILER TEST CLASS
 	===========================================================
@@ -11,13 +11,16 @@ SuperStrict
 Import "base.directorytree.bmx"
 Import "app.testcompiler.bmx" 'containing the compiler specific test class
 
+Global SCT_VERSION:String = "0.1.0"
+
 Type TTestManager
 	Field tests:TList = CreateList()
-	Field dirTree:TDirectoryTree = new TDirectoryTree
+	Field dirTree:TDirectoryTree = New TDirectoryTree
 
 
-	Method Init:TTestManager()
-		return self
+	Method Init:TTestManager(args:String[])
+		ParseArgs(args)
+		Return Self
 	End Method
 
 
@@ -28,32 +31,32 @@ Type TTestManager
 
 	'generate a configuration which inherits from parental configurations
 	'in parental folders
-	Method GetInheritedConfig:TConfigMap( configFile:string, rootDirectory:string, currentDirectory:string )
+	Method GetInheritedConfig:TConfigMap( configFile:String, rootDirectory:String, currentDirectory:String )
 		'all found configs are stored within an array and get
 		'merged at the end - the top most array at last (to overwrite
 		'parental settings)
-		local configs:TConfigMap[]
+		Local configs:TConfigMap[]
 
 		'add the test's individual config if possible
-		if fileSize(currentDirectory+"/"+configFile) > 0
-			configs :+ [ new TConfigMap.Init(currentDirectory+"/"+configFile) ]
-		endif
+		If FileSize(currentDirectory+"/"+configFile) > 0
+			configs :+ [ New TConfigMap.Init(currentDirectory+"/"+configFile) ]
+		EndIf
 
 		'loop through all parental directories
-		local lastSlashPos:int = -1
-		while currentDirectory.StartsWith(rootDirectory)
-			if fileSize(currentDirectory+"/base.conf") > 0
-				configs :+ [ new TConfigMap.Init(currentDirectory+"/base.conf") ]
-			endif
+		Local lastSlashPos:Int = -1
+		While currentDirectory.StartsWith(rootDirectory)
+			If FileSize(currentDirectory+"/base.conf") > 0
+				configs :+ [ New TConfigMap.Init(currentDirectory+"/base.conf") ]
+			EndIf
 
 			'strip of deepest directory
 			lastSlashPos = currentDirectory.FindLast("/")
-			if lastSlashPos >= 0
-				currentDirectory = Left(currentDirectory, lastSlashPos)
-			else
+			If lastSlashPos >= 0
+				currentDirectory = currentDirectory[..lastSlashPos]
+			Else
 				'finished
 				currentDirectory = ""
-			endif
+			EndIf
 		Wend
 
 		'add the basic configuration at last - so it is the base
@@ -63,26 +66,27 @@ Type TTestManager
 
 
 		'return the merged config
-		return TConfigMap.CreateMerged(configs, true)
+		Return TConfigMap.CreateMerged(configs, True)
 	End Method
 
 
-	Method AddTestsFromDirectory( directory:string )
+	Method AddTestsFromDirectory( directory:String )
 		'create a new directory tree containing all files/dirs of
 		'interest for us
-		dirTree = new TDirectoryTree.Init(directory, ["bmx", "conf", "res"], null, ["*"], [".bmx"])
+		dirTree = New TDirectoryTree.Init(directory, ["bmx", "conf", "res"], Null, ["*"], [".bmx"])
 		dirTree.ScanDir()
 
 
 		'load *.bmx files
-		local testFiles:string[] = dirTree.GetFiles("", "bmx")
+		Local testFiles:String[] = dirTree.GetFiles("", "bmx")
 
 
-		local test:TTestCompiler
-		for local testFile:string = eachin testFiles
-			test = new TTestCompiler.Init(testFile).SetCompileFile(testFile)
+		Local test:TTestCompiler
+		For Local testFile:String = EachIn testFiles
+			test = New TTestCompiler.Init(testFile).SetCompileFile(testFile)
 			'try to load the expected result file
 			test.LoadExpectedOutput( StripExt(testFile) + ".res" )
+
 			'try to find a configuration for this test
 			test.config = GetInheritedConfig( StripAll(testFile) + ".conf", directory, ExtractDir(testFile) )
 
@@ -91,27 +95,76 @@ Type TTestManager
 	End Method
 
 
-	Method RunTests:int()
-		print "=== STARTING TESTS ==="
-		print "* AMOUNT OF TESTS: " + tests.count()
+	Method RunTests:Int()
+		Print "=== STARTING TESTS ==="
+		Print "* AMOUNT OF TESTS: " + tests.count()
 
-		For local test:TTestBase = eachin tests
+		For Local test:TTestBase = EachIn tests
 			test.Run()
 		Next
 
-		print "=== FINISHED TESTS ==="
-		print "* FAILED: "+ GetResultCount(TTestBase.RESULT_FAILED)
-		print "* ERROR: "+ GetResultCount(TTestBase.RESULT_ERROR)
-		print "* OK: "+ GetResultCount(TTestBase.RESULT_OK)
+		Print "=== FINISHED TESTS ==="
+		Print "* FAILED: "+ GetResultCount(TTestBase.RESULT_FAILED)
+		Print "* ERROR: "+ GetResultCount(TTestBase.RESULT_ERROR)
+		Print "* OK: "+ GetResultCount(TTestBase.RESULT_OK)
 	End Method
 
 
 	'returns how many tests got the specified resultType
-	Method GetResultCount:int( resultType:int = 0 )
-		local count:int = 0
-		For local test:TTestbase = eachin tests
-			if test.result = resultType then count:+ 1
+	Method GetResultCount:Int( resultType:Int = 0 )
+		Local count:Int = 0
+		For Local test:TTestbase = EachIn tests
+			If test.result = resultType Then count:+ 1
 		Next
-		return count
+		Return count
 	End Method
+	
+	Method ParseArgs(args:String[])
+	
+		Local count:Int
+		
+		If args.length = 0 Then
+			ShowUsage()
+		End If
+	
+		While count < args.length
+		
+			Local arg:String = args[count]
+			
+			If arg[..1] <> "-" Then
+				Exit
+			End If
+			
+			Select arg[1..]
+				Case "h"
+					ShowUsage()
+				Case "v"
+					ShowVersion()
+			End Select
+			
+			count:+ 1
+		Wend
+		
+		args = args[count..]
+		
+		If args.length = 0
+			Print "Test directory missing from command line."
+			End
+		End If
+		
+		AddTestsFromDirectory(args[0])
+	End Method
+
+	Method ShowUsage()
+		Print "usage : sct [-h] [-v] dir"
+		End
+	End Method
+	
+	Method ShowVersion()
+		Print "sct version " + SCT_VERSION
+		End
+	End Method
+	
 End Type
+
+

--- a/base.configmap.bmx
+++ b/base.configmap.bmx
@@ -1,4 +1,4 @@
-REM
+Rem
 	===========================================================
 	BASIC CONFIGURATION MAP
 	===========================================================
@@ -8,151 +8,151 @@ REM
 ENDREM
 SuperStrict
 Import BRL.Map
-
+Import BRL.FileSystem
 
 Type TConfigMap
 	Field values:TMap = CreateMap()
-	Field fileUri:string = ""
+	Field fileUri:String = ""
 
 
-	Method Init:TConfigMap( configFile:string="" )
-		if configFile <> "" then LoadFromFile(configFile)
+	Method Init:TConfigMap( configFile:String="" )
+		If configFile <> "" Then LoadFromFile(configFile)
 
-		return self
+		Return Self
 	End Method
 
 
 	'clear all key->value pairs
-	Method Reset:int()
+	Method Reset:Int()
 		values.Clear()
-		return TRUE
+		Return True
 	End Method
 
 
 	'create another configMap with the same values
 	Method Copy:TConfigMap()
-		local copyObj:TConfigMap = new TConfigMap
+		Local copyObj:TConfigMap = New TConfigMap
 
 		'copy values
-		for local key:string = eachin values.Keys()
+		For Local key:String = EachIn values.Keys()
 			copyObj.Add(key, Get(key))
 		Next
-		return copyObj
+		Return copyObj
 	End Method
 
 
 	'create a merged configMap of all given configurations (eg. base + extension)
-	Function CreateMerged:TConfigMap( configs:TConfigMap[], reversed:int = FALSE )
-		if configs.length = 0 then return null
+	Function CreateMerged:TConfigMap( configs:TConfigMap[], reversed:Int = False )
+		If configs.length = 0 Then Return Null
 
-		if reversed
-			local newConfigs:TConfigMap[]
-			for local i:int = 1 to configs.length
+		If reversed
+			Local newConfigs:TConfigMap[]
+			For Local i:Int = 1 To configs.length
 				newConfigs :+ [configs[configs.length - i]]
 			Next
 			configs = newConfigs
-		endif
+		EndIf
 
 
-		local result:TConfigMap = configs[0].copy()
-		for local i:int = 1 to configs.length-1
+		Local result:TConfigMap = configs[0].copy()
+		For Local i:Int = 1 To configs.length-1
 			'overwrite values or add new if not existing
-			for local key:string = eachin configs[i].values.Keys()
-				local value:object = configs[i].Get(key)
-				if value then result.Add(key, value)
+			For Local key:String = EachIn configs[i].values.Keys()
+				Local value:Object = configs[i].Get(key)
+				If value Then result.Add(key, value)
 			Next
 		Next
-		return result
+		Return result
 	End Function
 
 	'try to load the configuration from a file
-	Method LoadFromFile:int( fileUri:string )
+	Method LoadFromFile:Int( fileUri:String )
 		'skip resetting and loading if the file is not existing
-		if filesize(fileUri) < 0 then return FALSE
+		If FileSize(fileUri) < 0 Then Return False
 
-		self.fileUri = fileUri
+		Self.fileUri = fileUri
 
 		'remove old values
 		Reset()
 
-		local file:TStream = readfile(fileUri)
-		if not file
+		Local file:TStream = ReadFile(fileUri)
+		If Not file
 			'RuntimeError("ERROR: could not open file ~q"+fileUri+"~q for reading.")
-			print "ERROR: could not open file ~q"+fileUri+"~q for reading."
-			return FALSE
-		endif
+			Print "ERROR: could not open file ~q"+fileUri+"~q for reading."
+			Return False
+		EndIf
 
-		local line:string = ""
-		local splitPos:int = 0
-		local key:string, value:string
-		while not Eof(file)
-			line = readline(file)
+		Local line:String = ""
+		Local splitPos:Int = 0
+		Local key:String, value:String
+		While Not Eof(file)
+			line = ReadLine(file)
 
 			'skip #comments
-			if line.trim().Find("#") = 0 then continue
+			If line.Trim().Find("#") = 0 Then Continue
 
 			'find first "=" (later ones could come from arguments/params)
 			splitPos = line.Find("=")
 			'no splitter means no assignment
-			if splitPos < 0 then continue
+			If splitPos < 0 Then Continue
 
-			key = Left(line, splitPos).trim()
-			value = Mid(line, splitPos+2).trim()
+			key = line[..splitPos].Trim()
+			value = line[splitPos+1..].Trim()
 
 			Add(key, value)
-		wend
+		Wend
 
 		file.Close()
-		return TRUE
+		Return True
 	End Method
 
 
-	Method ToString:string()
-		local result:string = "TConfigMap"+"~n"
-		result :+ "-> file: "+self.fileUri+"~n"
+	Method ToString:String()
+		Local result:String = "TConfigMap"+"~n"
+		result :+ "-> file: "+Self.fileUri+"~n"
 		result :+ "-> keys:"+"~n"
-		for local key:string = eachin values.Keys()
-			result :+ "  -> "+key+" : "+string(values.ValueForKey(key))+"~n"
+		For Local key:String = EachIn values.Keys()
+			result :+ "  -> "+key+" : "+String(values.ValueForKey(key))+"~n"
 		Next
-		return result
+		Return result
 	End Method
 
 
-	Method Add:TConfigMap( key:string, data:object )
+	Method Add:TConfigMap( key:String, data:Object )
 		values.insert(key, data)
-		return self
+		Return Self
 	End Method
 
 
-	Method AddString:TConfigMap( key:string, data:string )
-		Add(key, object(data))
-		return self
+	Method AddString:TConfigMap( key:String, data:String )
+		Add(key, Object(data))
+		Return Self
 	End Method
 
 
-	Method AddNumber:TConfigMap( key:string, data:float )
-		Add( key, object( string(data) ) )
-		return self
+	Method AddNumber:TConfigMap( key:String, data:Float )
+		Add( key, Object( String(data) ) )
+		Return Self
 	End Method
 
 
-	Method Get:object( key:string, defaultValue:object=null )
-		local result:object = values.ValueForKey(key)
-		if result then return result
-		return defaultValue
+	Method Get:Object( key:String, defaultValue:Object=Null )
+		Local result:Object = values.ValueForKey(key)
+		If result Then Return result
+		Return defaultValue
 	End Method
 
 
-	Method GetString:string( key:string, defaultValue:string=null )
-		local result:object = Get(key)
-		if result then return String( result )
-		return defaultValue
+	Method GetString:String( key:String, defaultValue:String=Null )
+		Local result:Object = Get(key)
+		If result Then Return String( result )
+		Return defaultValue
 	End Method
 
 
-	Method GetInt:int( key:string, defaultValue:int = null )
-		local result:object = Get(key)
-		if result then return Int( float( String( result ) ) )
-		return defaultValue
+	Method GetInt:Int( key:String, defaultValue:Int = Null )
+		Local result:Object = Get(key)
+		If result Then Return Int( Float( String( result ) ) )
+		Return defaultValue
 	End Method
 End Type

--- a/base.processes.bmx
+++ b/base.processes.bmx
@@ -1,4 +1,4 @@
-REM
+Rem
 	===========================================================
 	PROCESS HANDLING CLASSES
 	===========================================================
@@ -23,26 +23,26 @@ Type TCodeTesterProcess
 	Field runAfterwards:TCodeTesterProcess
 
 
-	Method Init:TCodeTesterProcess( name:string, flags:Int = 0, runNow:Int=True )
+	Method Init:TCodeTesterProcess( name:String, flags:Int = 0, runNow:Int=True )
 ?MacOS
-		If FileType(name)=2
-			Local a:string = StripExt( StripDir(name) )
-			name:+"/Contents/MacOS/"+a
+		If FileType(name+".app")=FILETYPE_DIR
+			Local a:String = StripExt( StripDir(name) )
+			name:+".app/Contents/MacOS/"+a
 		EndIf
 ?
-		self.flags = flags
-		self.name = name
+		Self.flags = flags
+		Self.name = name
 
 		FlushZombies()
 
 		If runNow Then RunProcess()
-		Return self
+		Return Self
 	End Method
 
 
 	Method Alive:Int()
 		If handle
-			If fdProcessStatus(handle) then Return True
+			If fdProcessStatus(handle) Then Return True
 			handle = 0
 		EndIf
 		If waitingSince = 0 Then waitingSince = MilliSecs()
@@ -51,25 +51,25 @@ Type TCodeTesterProcess
 
 
 	Method IOAvailable:Int()
-		Return StandardIOAvailable() or ErrorIOAvailable()
+		Return StandardIOAvailable() Or ErrorIOAvailable()
 	End Method
 
 
 	Method Read:String()
-		local result:string = ""
-		if result="" then result = ReadErrorIO()
-		if result="" then result = ReadStandardIO()
-		return result
+		Local result:String = ""
+		If result="" Then result = ReadErrorIO()
+		If result="" Then result = ReadStandardIO()
+		Return result
 	End Method
 
 
 	Method ReadStandardIO:String()
-		If StandardIOAvailable() then Return standardIO.ReadLine().Replace("~r","").Replace("~n","")
+		If StandardIOAvailable() Then Return standardIO.ReadLine().Replace("~r","").Replace("~n","")
 	End Method
 
 
 	Method ReadErrorIO:String()
-		If ErrorIOAvailable() then Return errorIO.ReadLine().Replace("~r","").Replace("~n","")
+		If ErrorIOAvailable() Then Return errorIO.ReadLine().Replace("~r","").Replace("~n","")
 	End Method
 
 
@@ -87,15 +87,15 @@ Type TCodeTesterProcess
 		If standardIO
 			standardIO.Close()
 			standardIO = Null
-		endif
+		EndIf
 		If errorIO
 			errorIO.Close()
 			errorIO = Null
-		endif
+		EndIf
 
 		terminate()
 
-		If runAfterwards then runAfterwards.RunProcess()
+		If runAfterwards Then runAfterwards.RunProcess()
 	End Method
 
 
@@ -113,7 +113,7 @@ Type TCodeTesterProcess
 		Local infd:Int, outfd:Int, errfd:Int
 
 		handle = fdProcess(name, Varptr infd, Varptr outfd, Varptr errfd, flags)
-		If Not handle then Return Null
+		If Not handle Then Return Null
 
 		standardIO = TPipeStreamUTF8.Create(infd, outfd)
 		errorIO = TPipeStreamUTF8.Create(errfd, outfd)
@@ -126,16 +126,16 @@ Type TCodeTesterProcess
 	Function FlushZombies()
 		Local aliveList:TList = CreateList()
 		For Local p:TCodeTesterProcess = EachIn processes
-			If p.Alive() then aliveList.AddLast p
+			If p.Alive() Then aliveList.AddLast p
 		Next
 		processes = aliveList
 	End Function
 
 
 	Method Eof:Int()
-		If Alive() then Return False
-		If StandardIOAvailable() then return False
-		If ErrorIOAvailable() then return False
+		If Alive() Then Return False
+		If StandardIOAvailable() Then Return False
+		If ErrorIOAvailable() Then Return False
 		Return True
 	End Method
 
@@ -189,7 +189,7 @@ Type TPipeStreamUTF8 Extends TStream
 
 
 	Method ReadPipe:Byte[]()
-		local n:Int = ReadAvailable()
+		Local n:Int = ReadAvailable()
 		If n
 			Local bytes:Byte[] = New Byte[n]
 			Read(bytes, n)
@@ -207,11 +207,11 @@ Type TPipeStreamUTF8 Extends TStream
 
 	Method ReadChar:Int()
 		Local c:Int = _ReadByte()
-		If c < 128 then Return c
+		If c < 128 Then Return c
 		Local d:Int = _ReadByte()
-		If c < 224 then Return (c-192)*64 + (d-128)
+		If c < 224 Then Return (c-192)*64 + (d-128)
 		Local e:Int = _ReadByte()
-		If c < 240 then Return (c-224)*4096 + (d-128)*64 + (e-128)
+		If c < 240 Then Return (c-224)*4096 + (d-128)*64 + (e-128)
 	End Method
 
 
@@ -220,12 +220,12 @@ Type TPipeStreamUTF8 Extends TStream
 			Local buf:Short[1024], i:Int
 			'somehow "Eof()" returns False albeit there is nothing
 			'to read - that is why we check ReadAvailable() too
-			While Not Eof() and ReadAvailable()
+			While Not Eof() And ReadAvailable()
 				Local n:Int = ReadChar()
-				If n =  0 then Exit
-				If n = 10 then Exit
-				If n = 13 then Continue
-				If buf.length = i then buf = buf[..i+1024]
+				If n =  0 Then Exit
+				If n = 10 Then Exit
+				If n = 13 Then Continue
+				If buf.length = i Then buf = buf[..i+1024]
 				buf[i] = n
 				i:+1
 			Wend

--- a/sct.bmx
+++ b/sct.bmx
@@ -1,9 +1,9 @@
 SuperStrict
 
-Framework brl.retro
+Framework brl.standardio
 Import "app.testmanager.bmx"
 
-REM
+Rem
 	Readme:
 
 	Each test can be located somewhere within the given directory.
@@ -25,12 +25,13 @@ REM
 
 	Each configuration file inherits the configuration of a parent
 	folder's "base.conf" (which also inherits from its parent).
-END REM
+End Rem
 
 
 
 'adjust compiler path for this test class
-TTestCompiler.SetCompilerURI("/home/ronny/Arbeit/Programmieren/BlitzMax/bin/bmk")
+TTestCompiler.baseConfig.Add("bmk_path", "/home/ronny/Arbeit/Programmieren/BlitzMax/bin/bmk")
+
 'adjust base config for all instances of that type
 TTestCompiler.baseConfig.Add("app_type", "console")
 TTestCompiler.baseConfig.Add("app_arch", "x86") 'unused yet
@@ -39,6 +40,5 @@ TTestCompiler.baseConfig.Add("threaded", "0")
 TTestCompiler.baseConfig.Add("deleteBinaries", "1") 'delete binaries afterwards
 TTestCompiler.baseConfig.fileUri = "baseConfig"
 
-global testManager:TTestManager = new TTestManager.Init()
-testManager.AddTestsFromDirectory("sampleTests")
+Global testManager:TTestManager = New TTestManager.Init(AppArgs[1..])
 testManager.RunTests()


### PR DESCRIPTION
Fix for OS X gui build file names.
Added command-line parameters (-h -v dir)
Made bmk location a config option. Stop if bmk missing.
Added app_arch support.
Ignore *.bak files.
